### PR TITLE
Resolves gh-2: Adds support for USB host MIDI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/tinyusb"]
 	path = lib/tinyusb
 	url = https://github.com/hathach/tinyusb.git
+[submodule "lib/pico-pio-usb"]
+	path = lib/pico-pio-usb
+	url = https://github.com/sekigon-gonnoc/Pico-PIO-USB.git

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
     "cmake.configureSettings": {
         "PICO_SDK_PATH": "${workspaceFolder}/lib/pico-sdk"
     },
-    "cmake.sourceDirectory": "${workspaceFolder}"
+    "cmake.sourceDirectory": "${workspaceFolder}",
+    "cortex-debug.variableUseNaturalFormat": false
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(PICO_SDK_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib/pico-sdk)
 include(${PICO_SDK_PATH}/external/pico_sdk_import.cmake)
 include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
 
+set(PICO_PIO_USB_PATH ${CMAKE_CURRENT_LIST_DIR}/lib/pico-pio-usb)
 set(PICO_TINYUSB_PATH ${CMAKE_CURRENT_LIST_DIR}/lib/tinyusb)
 
 # Compiler settings
@@ -32,6 +33,7 @@ add_compile_options(-Wall)
 pico_sdk_init()
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/midi_uart_lib)
+add_subdirectory(${PICO_PIO_USB_PATH})
 
 set(SOURCE_FILES
     src/passthrough.cpp
@@ -51,13 +53,15 @@ target_include_directories(${NAME} PRIVATE
 )
 
 target_link_libraries(${NAME}
+    pico_pio_usb
     pico_stdlib
     ring_buffer_lib
     midi_uart_lib
     tinyusb_device
+    tinyusb_host
 )
 
-target_compile_definitions(${NAME} PRIVATE)
+target_compile_definitions(${NAME} PRIVATE PIO_USB_USE_TINYUSB)
 
 pico_add_extra_outputs(${NAME})
 
@@ -75,3 +79,20 @@ install(FILES
 set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
 set(CPACK_GENERATOR "ZIP" "TGZ")
 include(CPack)
+
+# Mark TinyUSB includes as system headers
+# To suppress warnings when -Wextra is set.
+if(TARGET tinyusb_common_base)
+    get_target_property(TINYUSB_INCLUDES tinyusb_common_base INTERFACE_INCLUDE_DIRECTORIES)
+    target_include_directories(tinyusb_common_base SYSTEM INTERFACE ${TINYUSB_INCLUDES})
+endif()
+
+if(TARGET tinyusb_device)
+    get_target_property(TINYUSB_INCLUDES tinyusb_device INTERFACE_INCLUDE_DIRECTORIES)
+    target_include_directories(tinyusb_device SYSTEM INTERFACE ${TINYUSB_INCLUDES})
+endif()
+
+if(TARGET tinyusb_host)
+    get_target_property(TINYUSB_INCLUDES tinyusb_host INTERFACE_INCLUDE_DIRECTORIES)
+    target_include_directories(tinyusb_host SYSTEM INTERFACE ${TINYUSB_INCLUDES})
+endif()

--- a/include/midi-parser.h
+++ b/include/midi-parser.h
@@ -93,19 +93,18 @@ void sig_MidiParser_noOpMessageCallback(
  *
  * @param sysexData pointer to the SysEx data chunk
  * @param size size of the SysEx data chunk
- * @param isFinal true if this chunk is the final chunk of the SysEx message
  * @param userData user context pointer passed during parser initialization
+ * @param isFinal true if this chunk is the final chunk of the SysEx message
  */
 typedef void (*sig_MidiParser_SysexChunkCallback)(
-    uint8_t* sysexData, size_t size, bool isFinal, void* userData);
+    uint8_t* sysexData, size_t size, void* userData, bool isFinal);
 
 /**
  * @brief A sysex chunk callback that does nothing.
  * This can be used if you don't need sysex support.
  */
 void sig_MidiParser_noOpSysexCallback(
-    uint8_t* sysexData, size_t size, bool isFinal,
-    void* userData);
+    uint8_t* sysexData, size_t size, void* userData, bool isFinal);
 
 /**
  * Signaletic MIDI Parser

--- a/include/tusb_config.h
+++ b/include/tusb_config.h
@@ -27,45 +27,27 @@
 #define _TUSB_CONFIG_H_
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 //--------------------------------------------------------------------
 // COMMON CONFIGURATION
 //--------------------------------------------------------------------
 
-// defined by board.mk
+// defined by compiler flags for flexibility
 #ifndef CFG_TUSB_MCU
-  #error CFG_TUSB_MCU must be defined
+#error CFG_TUSB_MCU must be defined
 #endif
 
-// RHPort number used for device can be defined by board.mk, default to port 0
-#ifndef BOARD_DEVICE_RHPORT_NUM
-  #define BOARD_DEVICE_RHPORT_NUM     0
-#endif
-
-// RHPort max operational speed can defined by board.mk
-// Default to Highspeed for MCU with internal HighSpeed PHY (can be port specific), otherwise FullSpeed
-#ifndef BOARD_DEVICE_RHPORT_SPEED
-  #if (CFG_TUSB_MCU == OPT_MCU_LPC18XX || CFG_TUSB_MCU == OPT_MCU_LPC43XX || CFG_TUSB_MCU == OPT_MCU_MIMXRT10XX || \
-       CFG_TUSB_MCU == OPT_MCU_NUC505  || CFG_TUSB_MCU == OPT_MCU_CXD56)
-    #define BOARD_DEVICE_RHPORT_SPEED   OPT_MODE_HIGH_SPEED
-  #else
-    #define BOARD_DEVICE_RHPORT_SPEED   OPT_MODE_FULL_SPEED
-  #endif
-#endif
-
-// Device mode with rhport and speed defined by board.mk
-#if   BOARD_DEVICE_RHPORT_NUM == 0
-  #define CFG_TUSB_RHPORT0_MODE     (OPT_MODE_DEVICE | BOARD_DEVICE_RHPORT_SPEED)
-#elif BOARD_DEVICE_RHPORT_NUM == 1
-  #define CFG_TUSB_RHPORT1_MODE     (OPT_MODE_DEVICE | BOARD_DEVICE_RHPORT_SPEED)
+#if CFG_TUSB_MCU == OPT_MCU_LPC18XX || CFG_TUSB_MCU == OPT_MCU_LPC43XX || CFG_TUSB_MCU == OPT_MCU_MIMXRT10XX || \
+    CFG_TUSB_MCU == OPT_MCU_NUC505 || CFG_TUSB_MCU == OPT_MCU_CXD56
+#define CFG_TUSB_RHPORT0_MODE     (OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED)
 #else
-  #error "Incorrect RHPort configuration"
+#define CFG_TUSB_RHPORT0_MODE     OPT_MODE_DEVICE
 #endif
 
 #ifndef CFG_TUSB_OS
-#define CFG_TUSB_OS               OPT_OS_NONE
+#define CFG_TUSB_OS                 OPT_OS_PICO
 #endif
 
 // CFG_TUSB_DEBUG is defined by compiler in DEBUG build
@@ -86,6 +68,17 @@
 #define CFG_TUSB_MEM_ALIGN          __attribute__ ((aligned(4)))
 #endif
 
+// Enable Device stack, Default is max speed that hardware controller could support with on-chip PHY
+#define CFG_TUD_ENABLED       1
+#define CFG_TUD_MAX_SPEED     OPT_MODE_DEFAULT_SPEED
+
+// Enable Host stack, Default is max speed that hardware controller could support with on-chip PHY
+#define CFG_TUH_ENABLED       1
+#define CFG_TUH_MAX_SPEED     OPT_MODE_DEFAULT_SPEED
+
+// Use pico-pio-usb as host controller for raspberry rp2040
+#define CFG_TUH_RPI_PIO_USB   1
+
 //--------------------------------------------------------------------
 // DEVICE CONFIGURATION
 //--------------------------------------------------------------------
@@ -95,18 +88,55 @@
 #endif
 
 //------------- CLASS -------------//
-#define CFG_TUD_CDC               0
-#define CFG_TUD_MSC               0
-#define CFG_TUD_HID               0
-#define CFG_TUD_MIDI              1
-#define CFG_TUD_VENDOR            0
+#define CFG_TUD_CDC             0
+#define CFG_TUD_MSC             0
+#define CFG_TUD_HID             0
+#define CFG_TUD_MIDI            1
+#define CFG_TUD_VENDOR          0
 
 // MIDI FIFO size of TX and RX
 #define CFG_TUD_MIDI_RX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
 #define CFG_TUD_MIDI_TX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
 
+//--------------------------------------------------------------------
+// HOST CONFIGURATION
+//--------------------------------------------------------------------
+
+//------------------------- Board Specific --------------------------
+
+// RHPort number used for host can be defined by board.mk, default to port 0
+#ifndef BOARD_TUH_RHPORT
+#define BOARD_TUH_RHPORT      0
+#endif
+
+// RHPort max operational speed can defined by board.mk
+#ifndef BOARD_TUH_MAX_SPEED
+#define BOARD_TUH_MAX_SPEED   OPT_MODE_DEFAULT_SPEED
+#endif
+
+//--------------------------------------------------------------------
+// Driver Configuration
+//--------------------------------------------------------------------
+
+// Size of buffer to hold descriptors and other data used for enumeration
+#define CFG_TUH_ENUMERATION_BUFSIZE 256
+
+#ifndef CFG_TUH_MEM_SECTION
+#define CFG_TUH_MEM_SECTION
+#endif
+
+#ifndef CFG_TUH_MEM_ALIGN
+#define CFG_TUH_MEM_ALIGN           __attribute__ ((aligned(4)))
+#endif
+
+#define CFG_TUH_HUB                 1
+// max device support (excluding hub device)
+#define CFG_TUH_DEVICE_MAX          (CFG_TUH_HUB ? 4 : 1) // hub typically has 4 ports
+
+#define CFG_TUH_MIDI                CFG_TUH_DEVICE_MAX
+
 #ifdef __cplusplus
- }
+}
 #endif
 
 #endif /* _TUSB_CONFIG_H_ */

--- a/include/uart-midi-port.h
+++ b/include/uart-midi-port.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <algorithm> // For min()
 #include "midi_uart_lib.h"
 #include "midi-port.h"
 
@@ -19,7 +18,7 @@ static const UARTConfig DEFAULT_UART_CONFIG = {
 template<size_t messageBufferSize = 4,
     size_t sysexBufferSize = 32,
     size_t readBufferSize = 4>
-class UARTMidiPort: MidiPort<
+class UARTMidiPort: public MidiPort<
     messageBufferSize, sysexBufferSize, readBufferSize> {
 public:
     void* midi_uart;
@@ -44,17 +43,14 @@ public:
         size_t numBytesRead = readBlock();
 
         while (numBytesRead > 0) {
-            size_t bytesToFeed = std::min(numBytesRead,
-                readBufferSize);
-
             sig_MidiParser_feedBytes(&this->midiParser,
-                this->readBuffer, bytesToFeed);
+                this->readBuffer, numBytesRead);
 
             numBytesRead = readBlock();
         }
     }
 
-    size_t write(uint8_t* buffer, uint32_t numBytes) {
+    void write(uint8_t* buffer, uint32_t numBytes) {
         uint8_t bytesWritten = midi_uart_write_tx_buffer(
                 midi_uart, buffer, numBytes);
 
@@ -63,7 +59,5 @@ public:
         }
 
         midi_uart_drain_tx_buffer(midi_uart);
-
-        return bytesWritten;
     }
 };

--- a/include/usb-midi-device-port.h
+++ b/include/usb-midi-device-port.h
@@ -9,8 +9,6 @@ template<size_t messageBufferSize = 4,
 class USBMidiDevicePort: public MidiPort<
     messageBufferSize, sysexBufferSize, readBufferSize> {
 public:
-    static constexpr size_t USB_MIDI_PACKET_SIZE = 4;
-
     void init(MidiParserConfig parserConfig = MidiParserConfig()) {
         tud_init(0);
         this->initParser(parserConfig);
@@ -22,20 +20,26 @@ public:
     }
 
     void read() {
-        while (tud_midi_available()) {
-            (void) tud_midi_packet_read(this->readBuffer);
+        size_t bytesRead = tud_midi_stream_read(this->readBuffer,
+            readBufferSize);
+
+        while (bytesRead > 0) {
             sig_MidiParser_feedBytes(&this->midiParser,
-                this->readBuffer, USB_MIDI_PACKET_SIZE);
+                            this->readBuffer, bytesRead);
+            bytesRead = tud_midi_stream_read(this->readBuffer,
+                readBufferSize);
         }
     }
 
-    void write(uint8_t* buffer, uint32_t numBytes) {
+    void write(uint8_t* buffer, size_t numBytes) {
         if (!tud_midi_mounted()) {
             // Bytes that can't be written because the USB port
             // isn't mounted don't count as dropped.
             return;
         }
 
+        // TODO: Handle virtual cables correctly.
+        // For now, just write MIDI data to the first virtual cable.
         uint32_t bytesWritten = tud_midi_stream_write(
             0, buffer, numBytes);
 

--- a/include/usb-midi-host-port.h
+++ b/include/usb-midi-host-port.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "pio_usb.h"
+#include "tusb.h"
+#include "midi-port.h"
+
+struct USBMidiHostPortCallbackState {
+    uint8_t* readBuffer;
+    size_t readBufferSize;
+    struct sig_MidiParser* midiParser;
+};
+
+static USBMidiHostPortCallbackState* USBMidiHostPort_stateSingleton;
+
+template<size_t messageBufferSize = 4,
+    size_t sysexBufferSize = 32,
+    size_t readBufferSize = 4>
+class USBMidiHostPort: public MidiPort<
+    messageBufferSize, sysexBufferSize, readBufferSize> {
+public:
+    static constexpr size_t USB_MIDI_PACKET_SIZE = 4;
+
+    USBMidiHostPortCallbackState callbackState;
+
+    void init(uint8_t usbDPPin,
+        MidiParserConfig parserConfig = MidiParserConfig()) {
+        this->initParser(parserConfig);
+        pio_usb_configuration_t pioUSBConfig = PIO_USB_DEFAULT_CONFIG;
+        pioUSBConfig.pin_dp = usbDPPin;
+        tuh_configure(1,
+            TUH_CFGID_RPI_PIO_USB_CONFIGURATION, &pioUSBConfig);
+        tuh_init(1);
+
+        setupCallbackState();
+    }
+
+    void setupCallbackState() {
+        callbackState.midiParser = &this->midiParser;
+        callbackState.readBuffer = this->readBuffer;
+        callbackState.readBufferSize = readBufferSize;
+
+        USBMidiHostPort_stateSingleton = &this->callbackState;
+    }
+
+    uint8_t* getReadBuffer() {
+        return this->readBuffer;
+    }
+
+    void tick() {
+        tuh_task();
+    }
+
+    void write(uint8_t* buffer, uint32_t numBytes) {
+        // TODO: Handle virtual cables correctly.
+        uint32_t bytesWritten = tuh_midi_stream_write(0, 0, buffer, numBytes);
+
+        if (bytesWritten < numBytes) {
+            this->numTXBytesDropped += (numBytes - bytesWritten);
+        }
+
+        tuh_midi_write_flush(0);
+    }
+};
+
+static int32_t mounts = 0;
+
+
+void tuh_midi_mount_cb(uint8_t idx,
+    const tuh_midi_mount_cb_t* mount_cb_data) {
+    (void) idx;
+    (void) mount_cb_data;
+    mounts++;
+}
+
+// Invoked when device with hid interface is un-mounted
+void tuh_midi_umount_cb(uint8_t idx) {
+    (void) idx;
+    mounts--;
+}
+
+void tuh_midi_rx_cb(uint8_t idx, uint32_t xferredBytes) {
+    (void) xferredBytes;
+    uint8_t* readBuffer = USBMidiHostPort_stateSingleton->readBuffer;
+    size_t readBufferSize = USBMidiHostPort_stateSingleton->readBufferSize;
+    struct sig_MidiParser* midiParser = USBMidiHostPort_stateSingleton->midiParser;
+
+    while(tuh_midi_packet_read(idx, readBuffer) > 0) {
+        sig_MidiParser_feedBytes(midiParser, readBuffer, readBufferSize);
+    }
+}
+
+void tuh_midi_tx_cb(uint8_t idx, uint32_t num_bytes) {
+    (void)idx;
+    (void)num_bytes;
+}
+

--- a/src/midi-parser.c
+++ b/src/midi-parser.c
@@ -22,12 +22,11 @@ void sig_MidiParser_noOpMessageCallback(
 }
 
 void sig_MidiParser_noOpSysexCallback(
-    uint8_t* sysexData, size_t size, bool isFinal,
-    void* userData) {
+    uint8_t* sysexData, size_t size, void* userData, bool isFinal) {
     (void)sysexData;
     (void)size;
-    (void)isFinal;
     (void)userData;
+    (void)isFinal;
 }
 
 static void sig_MidiParser_clearBuffer(uint8_t* buffer,
@@ -155,7 +154,7 @@ void sig_MidiParser_endSysexMessage(
     self->isParsingSysex = 0;
     self->runningStatusByte = 0;
     self->sysexCallback(self->sysexBuffer, self->sysexWriteIdx,
-        true, self->userData);
+        self->userData, true);
     self->sysexWriteIdx = 0;
 }
 
@@ -206,7 +205,8 @@ void sig_MidiParser_handleCompleteMIDIMessage(struct sig_MidiParser* self) {
     self->messageBuffer[0] = self->runningStatusByte;
 }
 
-void sig_MidiParser_feedByte(struct sig_MidiParser* self, uint8_t byte) {
+inline void sig_MidiParser_feedByte(struct sig_MidiParser* self,
+    uint8_t byte) {
     // Real-time messages (0xF8-0xFF) can occur at any time,
     // and are only single byte messages, so can be dispatched immediately.
     if (byte >= 0xF8) {

--- a/src/passthrough.cpp
+++ b/src/passthrough.cpp
@@ -115,8 +115,6 @@ int main() {
     mainLED.on();
 
     while (true) {
-        tuh_task();
-
         uartMidiPort.tick();
         usbDevice.tick();
         usbHost.tick();

--- a/src/passthrough.cpp
+++ b/src/passthrough.cpp
@@ -5,6 +5,7 @@
 #include "midi-port.h"
 #include "uart-midi-port.h"
 #include "usb-midi-device-port.h"
+#include "usb-midi-host-port.h"
 #include "midi-logger.h"
 
 #define CPU_CLOCK_SPEED_KHZ 240000
@@ -12,14 +13,14 @@
 #define MIDI_UART_NUM 0
 #define MIDI_UART_TX_GPIO 0
 #define MIDI_UART_RX_GPIO 1
-
+#define USB_HOST_DP_GPIO 12
 #define LOG_BUFFER_SIZE 1024 * 100
 
 LED mainLED;
 LED noteLED;
 UARTMidiPort uartMidiPort;
-USBMidiDevicePort usbMidiDevicePort;
-MIDILogger<LOG_BUFFER_SIZE> midiLogger;
+USBMidiDevicePort usbDevice;
+USBMidiHostPort usbHost;
 
 void handleLEDStateForMIDIMessage(uint8_t* message) {
     // Light up the LED when notes are on.
@@ -31,35 +32,42 @@ void handleLEDStateForMIDIMessage(uint8_t* message) {
     }
 }
 
-void writeMessageFromUART(uint8_t* message, size_t size) {
-    (void) uartMidiPort.write(message, size);
-    (void) usbMidiDevicePort.write(message, size);
-}
-
-void writeMessageFromUSBDevice(uint8_t* message, size_t size) {
-    // Only write to the UART; don't echo the message back to USB.
-    (void) uartMidiPort.write(message, size);
-}
-
-void onMIDIMessage(uint8_t* message, size_t size, void* userData) {
-    handleLEDStateForMIDIMessage(message);
-
-    if (userData == &uartMidiPort) {
-        writeMessageFromUART(message, size);
-    } else if (userData == &usbMidiDevicePort) {
-        writeMessageFromUSBDevice(message, size);
-    }
-
-    midiLogger.write(message, size);
-}
-
-void onSysexChunk(uint8_t* sysexData, size_t size, bool isFinal,
+void writeMessageFromUART(uint8_t* message, size_t size,
     void* userData) {
-    (void)userData;
-    (void)isFinal;
+    (void) userData;
+    // Write to all output ports.
+    uartMidiPort.write(message, size);
+    usbDevice.write(message, size);
+    usbHost.write(message, size);
+}
 
-    (void) uartMidiPort.write(sysexData, size);
-    (void) usbMidiDevicePort.write(sysexData, size);
+void writeMessageFromUSBDevice(uint8_t* message, size_t size,
+    void* userData) {
+    (void) userData;
+    // Only write to the UART and USB host port;
+    // don't echo the message back to the USB device port.
+    uartMidiPort.write(message, size);
+    usbHost.write(message, size);
+}
+
+void writeMessageFromUSBHost(uint8_t* message, size_t size,
+    void* userData) {
+    (void) userData;
+
+    // Only write to the UART and USB device port;
+    // don't echo the message back to the USB host port.
+    uartMidiPort.write(message, size);
+    usbDevice.write(message, size);
+}
+
+void onSysexChunk(uint8_t* sysexData, size_t size, void* userData,
+    bool isFinal) {
+    (void) userData;
+    (void) isFinal;
+
+    uartMidiPort.write(sysexData, size);
+    usbDevice.write(sysexData, size);
+    usbHost.write(sysexData, size);
 }
 
 int main() {
@@ -75,26 +83,34 @@ int main() {
     };
 
     MidiParserConfig uartParserConfig = {
-        .onMIDIMessage = onMIDIMessage,
+        .onMIDIMessage = writeMessageFromUART,
         .onSysexChunk = onSysexChunk,
         .userData = &uartMidiPort
     };
-
     uartMidiPort.init(uartConfig, uartParserConfig);
-    MidiParserConfig usbParserConfig = {
-        .onMIDIMessage = onMIDIMessage,
-        .onSysexChunk = onSysexChunk,
-        .userData = &usbMidiDevicePort
-    };
-    usbMidiDevicePort.init(usbParserConfig);
 
-    midiLogger.init();
+    MidiParserConfig usbDeviceParserConfig = {
+        .onMIDIMessage = writeMessageFromUSBDevice,
+        .onSysexChunk = onSysexChunk,
+        .userData = &usbDevice
+    };
+    usbDevice.init(usbDeviceParserConfig);
+
+    MidiParserConfig usbHostParserConfig = {
+        .onMIDIMessage = writeMessageFromUSBHost,
+        .onSysexChunk = onSysexChunk,
+        .userData = &usbHost
+    };
+    usbHost.init(USB_HOST_DP_GPIO, usbHostParserConfig);
 
     mainLED.on();
 
     while (true) {
+        tuh_task();
+
         uartMidiPort.tick();
-        usbMidiDevicePort.tick();
+        usbDevice.tick();
+        usbHost.tick();
     }
 
     noteLED.off();

--- a/src/passthrough.cpp
+++ b/src/passthrough.cpp
@@ -35,6 +35,9 @@ void handleLEDStateForMIDIMessage(uint8_t* message) {
 void writeMessageFromUART(uint8_t* message, size_t size,
     void* userData) {
     (void) userData;
+
+    handleLEDStateForMIDIMessage(message);
+
     // Write to all output ports.
     uartMidiPort.write(message, size);
     usbDevice.write(message, size);
@@ -44,6 +47,9 @@ void writeMessageFromUART(uint8_t* message, size_t size,
 void writeMessageFromUSBDevice(uint8_t* message, size_t size,
     void* userData) {
     (void) userData;
+
+    handleLEDStateForMIDIMessage(message);
+
     // Only write to the UART and USB host port;
     // don't echo the message back to the USB device port.
     uartMidiPort.write(message, size);
@@ -53,6 +59,8 @@ void writeMessageFromUSBDevice(uint8_t* message, size_t size,
 void writeMessageFromUSBHost(uint8_t* message, size_t size,
     void* userData) {
     (void) userData;
+
+    handleLEDStateForMIDIMessage(message);
 
     // Only write to the UART and USB device port;
     // don't echo the message back to the USB host port.
@@ -65,6 +73,7 @@ void onSysexChunk(uint8_t* sysexData, size_t size, void* userData,
     (void) userData;
     (void) isFinal;
 
+    // TODO: Correctly handle sysex routing.
     uartMidiPort.write(sysexData, size);
     usbDevice.write(sysexData, size);
     usbHost.write(sysexData, size);

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -91,7 +91,7 @@ enum
 uint8_t const desc_fs_configuration[] =
 {
   // Config number, interface count, string index, total length, attribute, power in mA
-  TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
+  TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
 
   // Interface number, string index, EP Out & EP In address, EP size
   TUD_MIDI_DESCRIPTOR(ITF_NUM_MIDI, 0, EPNUM_MIDI, 0x80 | EPNUM_MIDI, 64)
@@ -101,7 +101,7 @@ uint8_t const desc_fs_configuration[] =
 uint8_t const desc_hs_configuration[] =
 {
   // Config number, interface count, string index, total length, attribute, power in mA
-  TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
+  TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
 
   // Interface number, string index, EP Out & EP In address, EP size
   TUD_MIDI_DESCRIPTOR(ITF_NUM_MIDI, 0, EPNUM_MIDI, 0x80 | EPNUM_MIDI, 512)
@@ -131,11 +131,10 @@ uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
 char const* string_desc_arr [] =
 {
   (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
-  "Lichen",                      // 1: Manufacturer
-  "YouMe Transformer",           // 2: Product
-
+  "Lichen.coop",         // 1: Manufacturer
+  "YouMe Transformer",   // 2: Product
   // TODO: Generate this dynamically with pico_get_unique_board_id_string()
-  "123456",                      // 3: Serials, should use chip ID
+  NULL,                  // 3: Serials, should use chip ID
 };
 
 static uint16_t _desc_str[32];


### PR DESCRIPTION
This PR also refactors the other MIDI port implementations to only use TinyUSB's MIDI stream API. Eventually this should be refactored to use the packet API for writing and streams for reading.